### PR TITLE
More secure notify with user token

### DIFF
--- a/engines/core/app/helpers/core/bot_links_api_helper.rb
+++ b/engines/core/app/helpers/core/bot_links_api_helper.rb
@@ -25,8 +25,16 @@ module Core
 
     def self.notify_about_ticket(ticket, event)
       params = Hash.new
+
+      user = User.find(ticket.reporter_id)
+
+      bot_links = user.bot_links.where(active: true)
+      if bot_links.size > 0
+        params["token"] = bot_links[0].token
+      end
+
       params["subject"] = ticket.subject
-      params["email"] = User.find(ticket.reporter_id).email
+      params["email"] = user.email
       params["event"] = event
       self.notify('/ticket', params)
     end


### PR DESCRIPTION
Раньше нотификации посылались всем, кто указал нужный email, а не только email+токен. Сейчас более безопасно.